### PR TITLE
updated line 17 again, changed http to https

### DIFF
--- a/Bestsellers/BookListV2.js
+++ b/Bestsellers/BookListV2.js
@@ -14,7 +14,7 @@ import BookItem from './BookItem';
 
 const API_KEY = '73b19491b83909c7e07016f4bb4644f9:2:60667290';
 const QUERY_TYPE = 'hardcover-fiction';
-const API_STEM = 'http://api.nytimes.com/svc/books/v3/lists'
+const API_STEM = 'https://api.nytimes.com/svc/books/v3/lists'
 const ENDPOINT = `${API_STEM}/${QUERY_TYPE}?response-format=json&api-key=${API_KEY}`;
 
 class BookList extends Component {


### PR DESCRIPTION
i tried with this tutorial https://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ and figured out that it was easier to try if the nytimes api worked over https, it does
