### PR TITLE
Fix Warning: getInitialState was defined on a plain JavaScript class

### DIFF
--- a/Zebreto/src/components/Review/ViewCard.js
+++ b/Zebreto/src/components/Review/ViewCard.js
@@ -34,7 +34,7 @@ ContinueButton.propTypes = {
 class ViewCard extends Component {
   static displayName = 'ViewCard';
 
-  getInitialState() {
+  _getInitialState() {
     return {
       showingAnswer: false,
       wasCorrect: null
@@ -43,11 +43,11 @@ class ViewCard extends Component {
 
   constructor(props) {
     super(props);
-    this.state = this.getInitialState();
+    this.state = this._getInitialState();
   }
 
   _continue = () => {
-    this.setState(this.getInitialState());
+    this.setState(this._getInitialState());
     this.props.continue();
   }
 
@@ -89,7 +89,7 @@ class ViewCard extends Component {
         );
     });
   }
-  
+
   render() {
     var buttons = this._buttons();
     return (


### PR DESCRIPTION
> Warning: getInitialState was defined on ViewCard, a plain JavaScript class. This is only supported for classes created using React.createClass. Did you mean to define a state property instead?

What do you think about **prepending an underscore** to the method as a solution?

For your info, the 2 **whitespace** changes are apparently care of Atom editor.

By the way, the only other 2 occurrences of `getInitialState` that I found in Zebreto are okay: components with `React.createClass` instead of `class extends React.component`
* Decks/index.js
* Review/index.js

<img width="375" alt="zebreto getinitialstate" src="https://cloud.githubusercontent.com/assets/11862657/17567635/322bf624-5f0e-11e6-8fec-f6ed0a15dab1.png">
