### PR TITLE
Fix: Zebreto Input autoCapitalize none

### DIFF
--- a/Zebreto/src/components/Input.js
+++ b/Zebreto/src/components/Input.js
@@ -45,6 +45,7 @@ class Input extends Component {
         ref="newDeckInput"
         multiline={false}
         value={this.state.text}
+        autoCapitalize='none'
         autoCorrect={false}
         onChangeText={this._onChange}
         onSubmitEditing={this._onSubmit}/>


### PR DESCRIPTION
The excellent examples in the book are German vocabulary words in which the difference between **lowercase** and uppercase are significant for the **first letter**. Likewise for my first example of knitting abbreviations. For my second example of `npm` commands, even the name of the deck is lowercase.

Running on the iOS Simulator, the default value of the `autoCapitalize` seems to be `sentences` as stated below.

What do you think about `autoCorrect='none'` in the `Input` component which has 3 occurrences:
- **name** of a new deck
- **front** and **back** words of a new card

https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/#//apple_ref/occ/intfp/UITextInputTraits/autocapitalizationType

> The default value for this property is UITextAutocapitalizationTypeSentences.

By the way, I could not find the default value in React Native docs https://facebook.github.io/react-native/docs/textinput.html#view or in the code for TextInput. I did not research the default value in the underlying Android control.

<img width="375" alt="zebreto autocapitalize card" src="https://cloud.githubusercontent.com/assets/11862657/17570819/f2b06292-5f1b-11e6-9f90-175f9cad7691.png">

In the following screen shot, I had created the first deck after patching a cloned project before I slowed down to fork the repository so I could submit pull requests.

<img width="375" alt="zebreto autocapitalize deck" src="https://cloud.githubusercontent.com/assets/11862657/17570825/fa80ca98-5f1b-11e6-80f0-9e99f86a5465.png">
