### PR TITLE
Zebreto shuffle answers in ReviewStore makeReviews function

### DIFF
--- a/Zebreto/src/stores/ReviewStore.js
+++ b/Zebreto/src/stores/ReviewStore.js
@@ -99,8 +99,8 @@ export default Reflux.createStore({
           cardID: card.id,
           prompt: card[sideOne],
           correctAnswer: card[sideTwo],
-          answers: [card[sideTwo]].concat(
-            _.sample(_.pluck(others, sideTwo), 3))
+          answers: _.shuffle([card[sideTwo]].concat(
+            _.sample(_.pluck(others, sideTwo), 3)))
         };
       });
     };


### PR DESCRIPTION
Because lodash is new to me, when I read `return _.shuffle(reviews)` it caused me to look up at answers, and then realize that in the screen pictures in the book and in my own testing the correct answer appears first in the list.