### PR TITLE
Zebreto make Button disabled prop affect behavior of TouchableOpacity

### DIFF
--- a/Zebreto/src/components/Button.js
+++ b/Zebreto/src/components/Button.js
@@ -11,10 +11,10 @@ class Button extends Component {
   static displayName = 'Button';
 
   render() {
-    let opacity = this.props.disabled ? 1 : 0.5;
     return (
       <TouchableOpacity
-        activeOpacity={opacity}
+        activeOpacity={0.5}
+        disabled={this.props.disabled}
         onPress={this.props.onPress}
         style={[styles.wideButton, this.props.style]}>
         {this.props.children}

--- a/Zebreto/src/components/NewCard/index.js
+++ b/Zebreto/src/components/NewCard/index.js
@@ -18,9 +18,13 @@ class NewCard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      font: '',
+      front: '',
       back: ''
     };
+  }
+
+  _createDisabled() {
+    return this.state.front === '' || this.state.back === '';
   }
 
   _handleFront = (text) => {
@@ -58,6 +62,7 @@ class NewCard extends Component {
           onChange={this._handleBack}/>
 
         <Button style={styles.createButton}
+          disabled={this._createDisabled()}
           onPress={this._createCard}>
           <NormalText>Create Card</NormalText>
         </Button>


### PR DESCRIPTION
- `NewCard` did not prevent creating a card with **empty string** as either front, or back, or both.
- `NewCard` constructor had a **typo** `font` instead of `front` for initial state. This pull request supersedes #28
- The `disabled` prop of `Button` affected the appearance but not the **behavior** of `TouchableOpacity`. However, its base class has a `disabled` prop: https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#disabled

If you would like, I can submit a pull request to make **appearance** of `Button` distinct (before an attempted touch) when it is disabled. What do you think about text color gray instead of black?
