### PR TITLE
Zebreto fix breaking flex for update to React Native 0.32.0

### DIFF
--- a/Zebreto/package.json
+++ b/Zebreto/package.json
@@ -9,8 +9,8 @@
     "lodash": "^3.10.1",
     "md5": "^2.1.0",
     "moment": "^2.13.0",
-    "react": "15.0.2",
-    "react-native": "^0.26.3",
+    "react": "15.3.1",
+    "react-native": "^0.32.0",
     "reflux": "^0.4.1"
   }
 }

--- a/Zebreto/src/components/Button.js
+++ b/Zebreto/src/components/Button.js
@@ -38,9 +38,6 @@ export default Button;
 
 const styles = StyleSheet.create({
   wideButton: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    flex: 1,
     padding: 10,
     margin: 10,
     backgroundColor: colors.pink

--- a/Zebreto/src/components/Decks/Deck.js
+++ b/Zebreto/src/components/Decks/Deck.js
@@ -64,9 +64,6 @@ const styles = StyleSheet.create({
   editButton: {
     width: 60,
     backgroundColor: colors.pink2,
-    justifyContent: 'center',
-    alignItems: 'center',
-    alignSelf: 'center',
     padding: 0,
     paddingTop: 10,
     paddingBottom: 10,

--- a/Zebreto/src/components/Decks/DeckCreation.js
+++ b/Zebreto/src/components/Decks/DeckCreation.js
@@ -78,16 +78,6 @@ DeckCreation.propTypes = {
 export default DeckCreation;
 
 const styles = StyleSheet.create({
-  nameField: {
-    backgroundColor: colors.tan,
-    height: 40
-  },
-  wideButton: {
-    justifyContent: 'center',
-    flex: 1,
-    padding: 10,
-    margin: 10
-  },
   createDeck: {
     backgroundColor: colors.green
   }

--- a/Zebreto/src/components/Input.js
+++ b/Zebreto/src/components/Input.js
@@ -71,8 +71,6 @@ const styles = StyleSheet.create({
     height: 60
   },
   wideButton: {
-    justifyContent: 'center',
-    flex: 1,
     padding: 10,
     margin: 10
   }

--- a/Zebreto/src/components/LabeledInput.js
+++ b/Zebreto/src/components/LabeledInput.js
@@ -35,6 +35,7 @@ LabeledInput.propTypes = {
 
 const styles = StyleSheet.create({
   label: {
+    textAlign: 'left',
     paddingLeft: 10
   },
   wrapper: {

--- a/Zebreto/src/components/NewCard/index.js
+++ b/Zebreto/src/components/NewCard/index.js
@@ -91,9 +91,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.green
   },
   secondaryButton: {
+    flex: 1,
     backgroundColor: colors.blue
   },
   buttonRow: {
+    flex: 1,
     flexDirection: 'row'
   }
 });

--- a/Zebreto/src/components/NormalText.js
+++ b/Zebreto/src/components/NormalText.js
@@ -14,7 +14,7 @@ class NormalText extends Component {
 
   render() {
     return (
-      <Text style={[this.props.style, fonts.normal, scaled.normal]}>
+      <Text style={[styles.alignment, this.props.style, fonts.normal, styles.normal]}>
         {this.props.children}
       </Text>
       );
@@ -25,11 +25,13 @@ NormalText.propTypes = {
   style: Text.propTypes.style
 };
 
-const scaled = StyleSheet.create({
+const styles = StyleSheet.create({
+  alignment: {
+    textAlign: 'center'
+  },
   normal: {
     fontSize: width / scalingFactors.normal
   }
 });
 
 export default NormalText;
-


### PR DESCRIPTION
Because of a problem with animation when the navigator renders the next scene after I added some `console.info` statements and turned on Remote JS Debugging, I updated `devDependencies`
- React Native from 0.26.3 to 0.32.0
- React from 15.0.2 to 15.3.1

All pictures in this comment are for iPhone 6 simulator with Xcode 7.3.1 on OS X 10.11.6

<img width="375" alt="console navigator animation" src="https://cloud.githubusercontent.com/assets/11862657/18179470/8ffc0a34-7050-11e6-9663-2a0fec608911.png">

The update solved the debugging problem but caused a minor problem with layout of decks whose solution is described in https://github.com/facebook/react-native/releases/tag/v0.28.0

> flex styling property behavior now behaves slightly differently. If you previously used `flex: 1` where not necessary this change will likely break your layout as the measuring behavior is slightly different than before due to performance optimizations. Removing that unnecessary `flex: 1` will solve your layout in most cases.

The first two (out of three) pictures illustrate the layout problems for a deck while it is being created and after its cards have been created **after the update** and **before the code changes**

<img width="1125" alt="deckcard" src="https://cloud.githubusercontent.com/assets/11862657/18179731/d59d2342-7051-11e6-814f-3dce88b8d5d6.png">

Here are baseline pictures **before the update** and again **after the code changes** in this pull request:

<img width="1125" alt="deckcard" src="https://cloud.githubusercontent.com/assets/11862657/18179725/d17f1f2c-7051-11e6-87f6-51a09b620f98.png">

Here are pictures that remained consistent before, during, and after:

<img width="1125" alt="review" src="https://cloud.githubusercontent.com/assets/11862657/18179822/3645f8f4-7052-11e6-9cd4-8868fffd22dc.png">

The deleted styles in `DeckCreation` are unreferenced and redundant with component styles.

Concerning the `cloneElement` call to provide `textAlign: 'center'` for the child of `Button` instead of to `alignItems: 'center'` for `Button` itself: it is a minimal, but less than ideal change, because it would shadow the `style` prop of `NormalText` if there was any, as described in https://facebook.github.io/react/docs/top-level-api.html#react.cloneelement

> The resulting element will have the original element's props with the new props merged in shallowly.
