### PR TITLE
Use https instead of http

### DIFF
--- a/Bestsellers/BookListV2.js
+++ b/Bestsellers/BookListV2.js
@@ -14,7 +14,7 @@ import BookItem from './BookItem';
 
 const API_KEY = '73b19491b83909c7e07016f4bb4644f9:2:60667290';
 const QUERY_TYPE = 'hardcover-fiction';
-const API_STEM = 'http://api.nytimes.com/svc/books/v3/lists';
+const API_STEM = 'https://api.nytimes.com/svc/books/v3/lists';
 const ENDPOINT = `${API_STEM}/${QUERY_TYPE}?response-format=json&api-key=${API_KEY}`;
 
 class BookList extends Component {


### PR DESCRIPTION
If I use http on iOS 9.3 I get the error "Possible Unhandled Promise Rejection (id: 0): Network request failed"

See http://stackoverflow.com/questions/31254725/transport-security-has-blocked-a-cleartext-http
