### PR TITLE
Add country code to ZIP code

### DIFF
--- a/src/weather/open_weather_map.js
+++ b/src/weather/open_weather_map.js
@@ -2,7 +2,7 @@ const WEATHER_API_KEY = "bbeb34ebf60ad50f7893e7440a1e2b0b";
 const API_STEM = "http://api.openweathermap.org/data/2.5/weather?";
 
 function zipUrl(zip) {
-  return `${API_STEM}q=${zip}&units=imperial&APPID=${WEATHER_API_KEY}`;
+  return `${API_STEM}q=${zip},us&units=imperial&APPID=${WEATHER_API_KEY}`;
 }
 
 function fetchForecast(zip) {


### PR DESCRIPTION
Without the country code, the weather for the first matching postal code is returned.  Since the ZIP code is used, it seems safe to add `us` as the country code.